### PR TITLE
fix: unhide choices in pull-request template table

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 | Q               | A
 | --------------- | ---
-| Bug fix?        | no|yes
-| New feature?    | no|yes
-| API breaks?     | no|yes
-| Deprecations?   | no|yes
+| Bug fix?        | no/yes
+| New feature?    | no/yes
+| API breaks?     | no/yes
+| Deprecations?   | no/yes
 | Related tickets | fixes #X, partially #Y, mentioned in #Z
 | License         | Apache 2.0
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Update the pull-request template to make show table values.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The `yes` option was hidden.

Before:
![image](https://user-images.githubusercontent.com/8191198/166669739-66e951ef-6e7c-47ef-a964-f25b19971045.png)
After:
![image](https://user-images.githubusercontent.com/8191198/166669799-8c8b1c61-d4d8-4a8b-82ef-f7fe50fb1982.png)



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
